### PR TITLE
doc: clarify fips support for centos8.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ rhel_subscription_username  = "user@test.com"
 rhel_subscription_password  = "mypassword"
 ```
 
-Note: rhel_image_name should reference a PowerVS image for Red Hat Enterprise Linux 8.6 or 9.0.
+Note: rhel_image_name should reference a PowerVS image for Red Hat Enterprise Linux 8.6 or 9.0 or Centos 8.6. 
+Also, please note this automation does not support Centos with FIPS enabled.
 
 ## Start Install
 


### PR DESCRIPTION
Strengths the statement with regards to FIPS support with Centos.

Signed-off-by: Paul Bastide <pbastide@us.ibm.com>