### PR TITLE
Bump nbde from v1.2.0 to v1.3.0

### DIFF
--- a/modules/2_nbde/nbde.tf
+++ b/modules/2_nbde/nbde.tf
@@ -144,7 +144,7 @@ ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i inventory powervs-setup.yml 
   --extra-vars private_network_mtu="${var.private_network_mtu}"  \
   --extra-vars domain="${var.domain}"
 
-ansible-galaxy install linux-system-roles.nbde_server,v1.2.0
+ansible-galaxy install linux-system-roles.nbde_server,v1.3.0
 # Lock in the system_roles
 ansible-galaxy collection install fedora.linux_system_roles:==1.29.0
 ANSIBLE_HOST_KEY_CHECKING=False ansible-playbook -i inventory powervs-tang.yml


### PR DESCRIPTION
Upgraded nbde version from 1.2.0 to 1.3.0 and tested it successfully.

NBDE version to v1.3.0

We have tested the powervs-tang-infra-automation by upgrading nbde version from 1.2.0 to 1.3.0 and also tested it with ocp4 deployment. 
Following are the logs for the same

```
# oc debug node/osa21-master-0.nbde-0712-d533.ibm.com
sh-4.4# chroot /host
sh-4.4# sudo cryptsetup status root
/dev/mapper/root is active and is in use.
  type:    LUKS2
  cipher:  aes-cbc-essiv:sha256
  keysize: 256 bits
  key location: keyring
  device:  /dev/sdd4
  sector size:  512
  offset:  32768 sectors
  size:    250826719 sectors
  mode:    read/write

# oc debug node/osa21-worker-0.nbde-0712-d533.ibm.com
sh-4.4# chroot /host
sh-4.4# sudo cryptsetup status root
/dev/mapper/root is active and is in use.
  type:    LUKS2
  cipher:  aes-cbc-essiv:sha256
  keysize: 256 bits
  key location: keyring
  device:  /dev/sdf4
  sector size:  512
  offset:  32768 sectors
  size:    250826719 sectors
  mode:    read/write
  ```